### PR TITLE
Fix interrupt bugs that cause a triple fault

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ zinux.iso: zinux.bin
 	echo '    multiboot /boot/zinux.bin' >> iso/boot/grub/grub.cfg
 	echo '    boot' >> iso/boot/grub/grub.cfg
 	echo '}' >> iso/boot/grub/grub.cfg
-	grub2-mkrescue --output $@ iso
+	grub-mkrescue --output $@ iso
 	rm -Rf iso/
 
 run: zinux.iso

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ zinux.iso: zinux.bin
 	echo '    multiboot /boot/zinux.bin' >> iso/boot/grub/grub.cfg
 	echo '    boot' >> iso/boot/grub/grub.cfg
 	echo '}' >> iso/boot/grub/grub.cfg
-	grub-mkrescue --output $@ iso
+	grub2-mkrescue --output $@ iso
 	rm -Rf iso/
 
 run: zinux.iso

--- a/gdt.c
+++ b/gdt.c
@@ -1,9 +1,8 @@
 #include "gdt.h"
 
 gdt_t GDT[GDT_ENTRY_COUNT];
-gdt_ptr_t pGDT;
 
-void GDT_flush();
+void GDT_flush(gdt_ptr_t *gdtr);
 
 void GDT_create(gdt_t *gdt, uint32_t base, uint32_t limit, uint8_t access, uint8_t flags)
 {
@@ -29,14 +28,15 @@ uint32_t GDT_getLimit(gdt_t *gdt)
 
 void GDT_init(void)
 {
+    gdt_ptr_t gdtr;
     GDT_create(&GDT[GDT_ENTRY_NULL], 0, 0, 0, 0);
     GDT_create(&GDT[GDT_ENTRY_CODE], 0, 0xFFFFFFFF, 0x9A, 0xCF);        // ring 0 (kernel), code
     GDT_create(&GDT[GDT_ENTRY_DATA], 0, 0xFFFFFFFF, 0x92, 0xCF);        // ring 0 (kernel), data
 
-    pGDT.size = sizeof(GDT) - 1;
-    pGDT.address = (uint32_t)&GDT;
+    gdtr.size = sizeof(GDT) - 1;
+    gdtr.address = (uint32_t)&GDT;
 
-    GDT_flush();
+    GDT_flush(&gdtr);
 }
 
 uint16_t GDT_codeSegmentSelector(void)

--- a/gdt.h
+++ b/gdt.h
@@ -32,7 +32,6 @@ uint32_t GDT_getLimit(gdt_t *gdt);
 #define GDT_ENTRY_COUNT     3
 
 extern gdt_t GDT[GDT_ENTRY_COUNT];
-extern gdt_ptr_t pGDT;
 
 void GDT_init(void);
 uint16_t GDT_codeSegmentSelector(void);

--- a/idt.c
+++ b/idt.c
@@ -6,14 +6,13 @@
 #include "tty.h"
 
 idt_t IDT[IDT_ENTRY_COUNT];
-idt_ptr_t pIDT;
 
-void IDT_flush(void);
+void IDT_flush(idt_ptr_t *idtr);
 
 void IDT_create(idt_t *idt, uint32_t address, uint16_t selector, uint8_t flags)
 {
     idt->addressLo = address & 0xFFFF;
-    idt->addressHi = (address << 16) & 0xFFFF;
+    idt->addressHi = (address & 0xFFFF0000)>>16;
     idt->selector = selector;
     idt->flags = flags;
     idt->reserved = 0;
@@ -22,15 +21,14 @@ void IDT_create(idt_t *idt, uint32_t address, uint16_t selector, uint8_t flags)
 void IDT_init(void)
 {
     uint16_t codeSegment = GDT_codeSegmentSelector();
-    uint8_t idtGate = 0x0E;
-    //idtGate = 0x8E;
+    uint8_t idtGate = 0x8E;
 
     uint32_t i;
     for(i = 0; i < IDT_ENTRY_COUNT; i++)
         IDT_create(&IDT[i], (uint32_t)IRQHandlerIgnore, codeSegment, idtGate);
 
     IDT_create(&IDT[0x20 + 0], (uint32_t)IRQHandler00, codeSegment, idtGate);
-    IDT_create(&IDT[0x20 + 1], (uint32_t)IRQHandler00, codeSegment, idtGate);
+    IDT_create(&IDT[0x20 + 1], (uint32_t)IRQHandler01, codeSegment, idtGate);
     IDT_create(&IDT[0x20 + 2], (uint32_t)IRQHandler00, codeSegment, idtGate);
     IDT_create(&IDT[0x20 + 3], (uint32_t)IRQHandler00, codeSegment, idtGate);
     IDT_create(&IDT[0x20 + 4], (uint32_t)IRQHandler00, codeSegment, idtGate);
@@ -40,5 +38,5 @@ void IDT_init(void)
     idtr.size = sizeof(IDT) - 1;
     idtr.address = (uint32_t)&IDT;
 
-    IDT_flush();
+    IDT_flush(&idtr);
 }

--- a/idt.h
+++ b/idt.h
@@ -5,11 +5,11 @@
 
 typedef struct idt_s
 {
-    uint16_t addressHi;
+    uint16_t addressLo;
     uint16_t selector;
     uint8_t reserved;
     uint8_t flags;
-    uint16_t addressLo;
+    uint16_t addressHi;
 } __attribute__((packed)) idt_t;
 
 typedef struct idt_ptr_s
@@ -24,8 +24,6 @@ void IDT_create(idt_t *idt, uint32_t address, uint16_t selector, uint8_t flags);
 #define IDT_ENTRY_COUNT     256
 
 extern idt_t IDT[IDT_ENTRY_COUNT];
-extern idt_ptr_t pIDT;
-
 void IDT_init(void);
 
 #endif // __IDT_H__

--- a/irq.c
+++ b/irq.c
@@ -5,7 +5,7 @@
 
 void PIC_sendEOI(uint8_t irq)
 {
-	if(irq >= 8)
+	if((irq-32) >= 8)
 		outb(PORT_PIC_MASTER_B,PIC_EOI);
 
 	outb(PORT_PIC_MASTER_A,PIC_EOI);

--- a/irq.c
+++ b/irq.c
@@ -3,9 +3,25 @@
 #include "port.h"
 #include "tty.h"
 
+void PIC_sendEOI(uint8_t irq)
+{
+	if(irq >= 8)
+		outb(PORT_PIC_MASTER_B,PIC_EOI);
+
+	outb(PORT_PIC_MASTER_A,PIC_EOI);
+}
+
 uint32_t IRQHandler(uint8_t irq, uint32_t esp)
 {
-    TTY_puts("INTERRUPT");
+    if (irq == 33)
+    {
+        /* Keyboard Handler */
+        inb(0x60); /* read keystroke so next interrupt will occur */
+        TTY_puts("KEYINT ");
+    }
+
+    /* Send EOI or we won't get further interrupts */
+    PIC_sendEOI(irq);
 
     return esp;
 }

--- a/kernel.c
+++ b/kernel.c
@@ -30,5 +30,5 @@ void kernelMain(void *multiboot, uint32_t magicNumber)
 
     TTY_setColor(COLOR_BLACK, COLOR_RED);
 
-    while(1);
+    while(1) __asm__ ("hlt");
 }

--- a/loader.S
+++ b/loader.S
@@ -17,15 +17,15 @@ loader:
     push %ebx
     call kernelMain
 
-_stop:
     cli
+_stop:
     hlt
     jmp _stop
 
 .global GDT_flush
-.extern pGDT
 GDT_flush:
-    lgdt (pGDT)
+    movl 4(%esp), %eax
+    lgdt (%eax)
     movw $0x10, %ax
     movw %ax, %ds
     movw %ax, %es
@@ -37,12 +37,12 @@ _flush:
     ret
 
 .global IDT_flush
-.extern pIDT
 IDT_flush:
-    lidt (pIDT)
+    movl 4(%esp), %eax
+    lidt (%eax)
     ret
 
 .section .bss
-.space 2 * 1024 * 1024
+.space 1 * 1024 * 1024
 
 kernel_stack:

--- a/port.h
+++ b/port.h
@@ -7,6 +7,7 @@
 #define PORT_PIC_MASTER_B           0x21
 #define PORT_PIC_SLAVE_A            0xA0
 #define PORT_PIC_SLAVE_B            0xA1
+#define PIC_EOI		                0x20		/* End-of-interrupt command code */
 
 void outb(uint16_t port, uint8_t data);
 uint8_t inb(uint16_t port);


### PR DESCRIPTION
This is in response to this [Stackoverflow question](http://stackoverflow.com/q/44000661/3857942). There are a number of issues that needed fixing:

- Rather than use global variables `pGDT` and `pIDT`, pass these as a parameter to `IDT_flush` and `GDT_flush`. Modify those functions to use a function argument with the pointer in it. One primary issue originally was that `pIDT` wasn't being initialized. The IDT pointer pointed nowhere so the IDT pointer was effectively corrupt
- In structure `idt_s` you had `addressHi` and `addressLo` swapped around
- Function `IDT_create` has the wrong pointer arithmetic on the address
- `idtGate` was 0x0E when it should have been 0x8E. The commented out code was correct
- I reduce the stack size to 1mb just in case you wish to ever use the bootloader directly with QEMU using the `-kernel` parameter. You can put it back to 2mb if you don't care.
- Added function `PIC_sendEOI` that sends an End of Interrupt (EOI) so that we can receive future interrupts.
- Enabled a keyboard handler that pulls a character from the keyboard and throws it away. We do a read from the keyboard, otherwise we'd never get future keyboard interrupts. Display a message when the interrupt is fired.
- Enable the timer tick interrupt, but do nothing with it
- Minor improvement to `kernelMain` at the main `while(1)` loop.  Call `hlt` instruction in the loop so that it waits for next interrupt.